### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ they will listen."
 tirdad is a kernel module to hot-patch the Linux kernel
 to generate random TCP Initial Sequence Numbers for IPv4 TCP connections.
 
-You can refer to this bog post to get familiar with the original issue:
+You can refer to this blog post to get familiar with the original issue:
 
 - An analysis of TCP secure SN generation in Linux and its privacy issues
 - https://bitguard.wordpress.com/?p=982


### PR DESCRIPTION
## Summary
- Correct README typo by changing "bog post" to "blog post".

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af4d3a5094832080dc089c2436ff0d