### PR TITLE
Disable livepatch on exit

### DIFF
--- a/module/tirdad.c
+++ b/module/tirdad.c
@@ -119,6 +119,14 @@ int hook_init(void){
 }
 
 void hook_exit(void){
+	int ret;
+
+	ret = klp_disable_patch(&patch);
+	if (ret) {
+		_s_out(1,"Failed to remove hooks: %d", ret);
+		return;
+	}
+
 	_s_out(0,"Removed hooks. Exiting normally.");
 }
 


### PR DESCRIPTION
## Summary
- Ensure module cleanup disables livepatch hook
- Report failure to disable patch before logging exit message

## Testing
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af5425278c832084e0b2f33edd72c8