### PR TITLE
Add AGENTS.md with project context and upstream PR notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Instructions for tirdad
+
+## Project Overview
+
+tirdad is a Linux kernel module that randomizes TCP Initial Sequence Numbers
+(ISN) for IPv4 and IPv6 to prevent CPU information leak side-channels. It uses
+the kernel livepatch framework.
+
+- **Upstream repo**: Kicksecure/tirdad
+- **Language**: C (Linux kernel module)
+- **Build**: `make` (requires kernel headers)
+- **Packaging**: Debian/DKMS
+
+## Known Upstream PR
+
+There is an open upstream PR for adding `__printf` format attribute annotation
+to `_s_out()`:
+
+https://github.com/Kicksecure/tirdad/pull/3
+
+The maintainer's position is that for a module this small (5 call sites, all
+string literals with no format arguments), the change is too pedantic to
+upstream. Do not re-propose this change.

--- a/module/tirdad.c
+++ b/module/tirdad.c
@@ -23,13 +23,13 @@
 #define CGREEN				""
 #endif
 
-__printf(2, 3) void _s_out(u8 err, const char *fmt, ...);
+void _s_out(u8 err, char *fmt, ...);
 
 int hook_init(void);
 void hook_exit(void);
 
 
-void _s_out(u8 err, const char *fmt, ...){
+void _s_out(u8 err, char *fmt, ...){
 	va_list argp;
 	char msg_fmt[255];
 

--- a/module/tirdad.c
+++ b/module/tirdad.c
@@ -23,13 +23,13 @@
 #define CGREEN				""
 #endif
 
-void _s_out(u8 err, char *fmt, ...);
+__printf(2, 3) void _s_out(u8 err, const char *fmt, ...);
 
 int hook_init(void);
 void hook_exit(void);
 
 
-void _s_out(u8 err, char *fmt, ...){
+void _s_out(u8 err, const char *fmt, ...){
 	va_list argp;
 	char msg_fmt[255];
 


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` documenting project overview and build instructions
- Record upstream maintainer feedback from [Kicksecure/tirdad#3](https://github.com/Kicksecure/tirdad/pull/3): the `__printf` format attribute annotation on `_s_out()` was deemed too pedantic for a module this small
- Prevents future agents from re-proposing the same change

## No source code changes
Only `AGENTS.md` is added. The `module/tirdad.c` source is untouched.

https://claude.ai/code/session_018RqemCaZDrhmA7jV2eBgQ3