### PR TITLE
Update AGENTS.md with PR #4 compiler flags rejection notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,32 @@ the kernel livepatch framework.
 - **Build**: `make` (requires kernel headers)
 - **Packaging**: Debian/DKMS
 
-## Known Upstream PR
+## Rejected Upstream Changes
 
-There is an open upstream PR for adding `__printf` format attribute annotation
-to `_s_out()`:
+### PR #3: `__printf` format attribute on `_s_out()`
 
 https://github.com/Kicksecure/tirdad/pull/3
 
-The maintainer's position is that for a module this small (5 call sites, all
-string literals with no format arguments), the change is too pedantic to
-upstream. Do not re-propose this change.
+Proposed adding `__printf(2, 3)` attribute and `const char *` qualifier to the
+`_s_out()` function for compile-time format string checking.
+
+**Rejected.** The original author (0xsirus) stated: "The existing print
+function is fine and the suggested change is not necessary." The module is too
+small (5 call sites, all string literals with no format arguments) for this to
+provide meaningful value. Do not re-propose this change.
+
+### PR #4: Compiler warning flags in module Makefile
+
+https://github.com/Kicksecure/tirdad/pull/4
+
+Proposed adding `ccflags-y` flags (`-Wall`, `-Wextra`, `-Werror`,
+`-Wformat-security`, `-Wformat-nonliteral`, `-Wno-unused-parameter`) to
+`module/Makefile`, plus the same `__printf`/`const` changes from PR #3.
+
+**Rejected.** Reviewer (ArrayBolt3) noted:
+- The `__printf`/`const` portion was an exact duplicate of PR #3.
+- The Linux kernel's Kbuild system already sets appropriate compiler warning
+  flags for modules. Out-of-tree modules should not hardcode their own flags.
+- For development-time warnings, use `make KCFLAGS=-W` instead.
+
+Do not add `ccflags-y` warning flags to the module Makefile.


### PR DESCRIPTION
## Summary

- Updates AGENTS.md to document the rejection of PR #4 (compiler warning flags in module Makefile)
- Restructures the "Known Upstream PR" section into "Rejected Upstream Changes" with entries for both PR #3 and PR #4
- Captures the key lessons so future agents don't repeat these proposals

## What was added

**PR #4 rejection notes:** ArrayBolt3 rejected hardcoding `ccflags-y` warning flags (`-Wall`, `-Wextra`, `-Werror`, etc.) in the module Makefile because:
1. The `__printf`/`const` changes were an exact duplicate of already-rejected PR #3
2. Linux Kbuild already sets appropriate compiler warning flags for modules — out-of-tree modules should not override them
3. For development-time warnings, use `make KCFLAGS=-W` instead

## Test plan

- [x] AGENTS.md is valid markdown
- [x] Branch is cleanly rebased on current master (no stale compile flag changes)

https://claude.ai/code/session_01TGuvnh5mbFAcuVWNxMcuKP